### PR TITLE
Mulitple Unpacking not allowed

### DIFF
--- a/python_package/madflow/parameters.py
+++ b/python_package/madflow/parameters.py
@@ -4,6 +4,7 @@
 from .config import DTYPE, DTYPECOMPLEX, complex_me, float_me, run_eager
 import numpy as np
 import tensorflow as tf
+from itertools import chain
 
 GS_SIGNATURE = [tf.TensorSpec(shape=[None], dtype=DTYPECOMPLEX)]
 ALPHAS_SIGNATURE = [tf.TensorSpec(shape=[None], dtype=DTYPE)]
@@ -68,7 +69,7 @@ class Model:
             return self._constants
         if not self._constants:
             return results
-        return *self._constants, *results
+        return list(chain.from_iterable([self._constants, results]))
 
     def get_masses(self):
         """Get the masses that entered the model as constants"""


### PR DESCRIPTION
This PR is intended to fix issue #13 

The following line caused syntax error. Probably because python version compatibility problems. Moreover  we have to ensure that AutoGraph is properly converting `tf.functions`.
https://github.com/N3PDF/madflow/blob/8a9ac39241fbf391ed02a020f90007c81767832d/python_package/madflow/parameters.py#L71