### PR TITLE
Autodiscover masses

### DIFF
--- a/example/cuts_example.py
+++ b/example/cuts_example.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
         default="g g > t t~",
     )
     arger.add_argument(
-        "-m", "--massive_particles", help="Number of massive particles", type=int, default=2
+        "-m", "--massive_particles", help="Number of massive particles to apply cuts differently", type=int, default=2
     )
     arger.add_argument("-g", "--variable_g", help="Use variable g_s", action="store_true")
     arger.add_argument(

--- a/python_package/madflow/parameters.py
+++ b/python_package/madflow/parameters.py
@@ -71,13 +71,27 @@ class Model:
             return results
         return list(chain.from_iterable([self._constants, results]))
 
+    def get_mass(self, particle, safe=False):
+        """Get the mass of the given particle
+        If the particle is not found defaults to mass=0 unless safe=True"""
+        if particle.endswith("~"):
+            particle = particle[:-1]
+        massive_name = f"mdl_M{particle.upper()}"
+        if hasattr(self._tuple_constants, massive_name):
+            return getattr(self._tuple_constants, massive_name)
+        if safe:
+            raise ValueError(f"Particle {particle} is not massive in this model")
+        return 0.0
+
     def get_masses(self):
         """Get the masses that entered the model as constants"""
         masses = []
+        massive_particles = []
         for key, val in self._tuple_constants._asdict().items():
             if key.startswith("mdl_M"):
                 masses.append(val)
-        return masses
+                massive_particles.append(key[-1])
+        return masses, massive_particles
 
     def parse_parameter(self, parameter_name):
         """Parse a (constant) parameter given its string name"""

--- a/python_package/madflow/scripts/madflow_exec.py
+++ b/python_package/madflow/scripts/madflow_exec.py
@@ -233,9 +233,6 @@ def madflow_main(args=None, quick_return=False):
         default="g g > t t~",
     )
     arger.add_argument(
-        "-m", "--massive_particles", help="Number of massive particles", type=int, default=2
-    )
-    arger.add_argument(
         "-q",
         "--fixed_scale",
         help="Fix value of scale muR=muF (and alphas(q)), "
@@ -325,16 +322,11 @@ def madflow_main(args=None, quick_return=False):
     # The number of particles is the same for all matrices
     nparticles = int(matrices[0].nexternal)
     ndim = (nparticles - 2) * 4 + 2
-    massive_particles = args.massive_particles
-    non_massive = nparticles - massive_particles - 2
-    # For this script the massive particles go always first
-    # as the output should always be to particles and not wrappers
-    # _if_ the number of masses is below the number of massive particle
-    param_masses = models[0].get_masses()
-    if len(param_masses) < massive_particles:
-        param_masses *= massive_particles
-    param_masses = [i.numpy() for i in param_masses]
-    masses = param_masses + [0.0] * non_massive
+    # Try to autodiscover massive states
+    final_state = args.madgraph_process.split(">")[-1].strip()
+    final_state_particles = final_state.split(" ")
+    # Clean the antiparticles
+    masses = [models[0].get_mass(p) for p in final_state_particles]
     logger.debug("Masses: %s", masses)
     ###################################################
 

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ Using this script is possible to run any process at Leading Order, integrated wi
   madflow --help
 ```
 ```bash
-    [-h] [-v] [-p PDF] [--no_pdf] [-c] [--madgraph_process MADGRAPH_PROCESS] [-m MASSIVE_PARTICLES] [-g] [--pt_cut PT_CUT] [--histograms]
+    [-h] [-v] [-p PDF] [--no_pdf] [-c] [--madgraph_process MADGRAPH_PROCESS] [-g] [--pt_cut PT_CUT] [--histograms]
 
     optional arguments:
       -h, --help            show this help message and exit
@@ -104,8 +104,6 @@ Using this script is possible to run any process at Leading Order, integrated wi
       -c, --enable_cuts     Enable the cuts
       --madgraph_process MADGRAPH_PROCESS
                             Set the madgraph process to be run
-      -m MASSIVE_PARTICLES, --massive_particles MASSIVE_PARTICLES
-                            Number of massive particles
       -g, --variable_g      Use variable g_s
       --pt_cut PT_CUT       Minimum pt for the outgoint particles
       --histograms          Generate LHE files/histograms


### PR DESCRIPTION
This fixes the bug @marcozaro found the other day where the automatic script would fail for some combinations of massive particles (the generated output was ok because the massive particles were written explicitly).

There's still the aloha-ish bug 

```bash
    File "/tmp/mad_vb9qwyl6/matrix_1_gg_ttxz.py", line 227, in smatrix  *
        ans += self.matrix(all_ps,hel,mdl_MT,mdl_MZ,mdl_WT,mdl_WZ,GC_50,GC_58,GC_10,GC_11)
    File "/tmp/mad_vb9qwyl6/matrix_1_gg_ttxz.py", line 268, in matrix  *
        w6= FFV2_5_1(w2,w4,-GC_50,GC_58,mdl_MT,mdl_WT)
    File "/tmp/mad_vb9qwyl6/aloha_1_gg_ttxz.py", line 84, in FFV2_5_1  *
        F1[i] += tmp[i]
```

which is coming from this python loop (and the same for `FFV2_5_2`)

```python
def FFV2_5_1(F2,V3,COUP1,COUP2,M1,W1):
    F1 = FFV2_1(F2,V3,COUP1,M1,W1)
    tmp = FFV5_1(F2,V3,COUP2,M1,W1)
    for i in range(2,6):
        F1[i] += tmp[i]
    return tf.stack(F1, axis=0)
```

to first approximation it should be something like this instead:

```python
def FFV2_5_1(F2,V3,COUP1,COUP2,M1,W1):
    F1 = FFV2_1(F2,V3,COUP1,M1,W1)
    tmp = FFV5_1(F2,V3,COUP2,M1,W1)
    return tf.concat([F1[0:2], tmp[2:] + F1[2:]], axis=0)
```

If any of you can change that you can add it to this PR.